### PR TITLE
Remove Prices and Seasons from appsettings

### DIFF
--- a/NeverNeverLand/Controllers/AdminController.cs
+++ b/NeverNeverLand/Controllers/AdminController.cs
@@ -1,0 +1,106 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using NeverNeverLand.Data;
+using NeverNeverLand.Models;
+using NeverNeverLand.Models.ViewModels;
+
+
+
+public class AdminController : Controller
+{
+    private readonly ApplicationDbContext _db;
+    public AdminController(ApplicationDbContext db) => _db = db;
+
+    [HttpGet]
+    public async Task<IActionResult> Index()
+    {
+        var vm = new AdminPricingViewModel
+        {
+            SeasonOptions = await _db.Seasons
+                .Where(s => s.IsActive)
+                .OrderByDescending(s => s.AlwaysOn).ThenBy(s => s.StartDate)
+                .Select(s => new SelectListItem { Value = s.Id.ToString(), Text = s.Name })
+                .ToListAsync(),
+
+            AdmissionTypeOptions = new List<SelectListItem>
+        {
+            new("Adult", "Adult"),
+            new("Child", "Child"),
+            new("Infant", "Infant")
+        },
+
+            Prices = await _db.Prices
+                .Include(p => p.Season)
+                .OrderByDescending(p => p.IsActive)
+                .ThenBy(p => p.Season.Name)
+                .ThenBy(p => p.AdmissionType)
+                .ToListAsync()
+        };
+
+        if (vm.SeasonOptions.Count > 0)
+            vm.SelectedSeasonId = int.Parse(vm.SeasonOptions[0].Value!);
+
+        // vm.SelectedAdmissionType already defaults to "Adult"
+        return View(vm);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreatePrice(AdminPricingViewModel vm)
+    {
+        if (!ModelState.IsValid)
+        {
+            vm.SeasonOptions = await _db.Seasons.Where(s => s.IsActive)
+                .OrderByDescending(s => s.AlwaysOn).ThenBy(s => s.StartDate)
+                .Select(s => new SelectListItem { Value = s.Id.ToString(), Text = s.Name })
+                .ToListAsync();
+
+            vm.AdmissionTypeOptions = new List<SelectListItem>
+        {
+            new("Adult","Adult"), new("Child","Child"), new("Infant","Infant")
+        };
+
+            vm.Prices = await _db.Prices
+                .Include(p => p.Season)
+                .OrderByDescending(p => p.IsActive)
+                .ThenBy(p => p.Season.Name)
+                .ThenBy(p => p.AdmissionType)
+                .ToListAsync();
+
+            return View("Index", vm);
+        }
+
+        var current = await _db.Prices
+            .Where(p => p.SeasonId == vm.SelectedSeasonId
+                     && p.AdmissionType == vm.SelectedAdmissionType
+                     && p.IsActive)
+            .ToListAsync();
+
+        foreach (var p in current) p.IsActive = false;
+
+        _db.Prices.Add(new Price
+        {
+            SeasonId = vm.SelectedSeasonId,
+            AdmissionType = vm.SelectedAdmissionType,
+            Amount = vm.Amount,
+            Currency = vm.Currency,
+            EffectiveStartUtc = DateTime.UtcNow,
+            IsActive = true
+        });
+
+        _db.PriceChangeLogs.Add(new PriceChangeLog
+        {
+            SeasonId = vm.SelectedSeasonId,
+            TicketId = 0,
+            ChangedByUserId = User?.Identity?.Name ?? "admin",
+            OldAmount = current.FirstOrDefault()?.Amount ?? 0m,
+            NewAmount = vm.Amount,
+            Currency = vm.Currency,
+            Note = $"Set {vm.SelectedAdmissionType} price"
+        });
+
+        await _db.SaveChangesAsync();
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/NeverNeverLand/Controllers/AdminController.cs
+++ b/NeverNeverLand/Controllers/AdminController.cs
@@ -35,7 +35,7 @@ public class AdminController : Controller
                 .Include(p => p.Season)
                 .OrderByDescending(p => p.IsActive)
                 .ThenBy(p => p.Season.Name)
-                .ThenBy(p => p.AdmissionType)
+                .ThenBy(p => p.Item)
                 .ToListAsync()
         };
 
@@ -65,7 +65,7 @@ public class AdminController : Controller
                 .Include(p => p.Season)
                 .OrderByDescending(p => p.IsActive)
                 .ThenBy(p => p.Season.Name)
-                .ThenBy(p => p.AdmissionType)
+                .ThenBy(p => p.Item)
                 .ToListAsync();
 
             return View("Index", vm);
@@ -73,7 +73,7 @@ public class AdminController : Controller
 
         var current = await _db.Prices
             .Where(p => p.SeasonId == vm.SelectedSeasonId
-                     && p.AdmissionType == vm.SelectedAdmissionType
+                     && p.Item == vm.SelectedAdmissionType
                      && p.IsActive)
             .ToListAsync();
 
@@ -82,7 +82,7 @@ public class AdminController : Controller
         _db.Prices.Add(new Price
         {
             SeasonId = vm.SelectedSeasonId,
-            AdmissionType = vm.SelectedAdmissionType,
+            Item = vm.SelectedAdmissionType,
             Amount = vm.Amount,
             Currency = vm.Currency,
             EffectiveStartUtc = DateTime.UtcNow,

--- a/NeverNeverLand/Controllers/HomeController.cs
+++ b/NeverNeverLand/Controllers/HomeController.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
+using System.Net.NetworkInformation;
 using Microsoft.AspNetCore.Mvc;
-using NeverNeverLand.Models;
+using NeverNeverLand.Models.ViewModels;
 
 namespace NeverNeverLand.Controllers
 {
@@ -14,6 +15,11 @@ namespace NeverNeverLand.Controllers
         }
 
         public IActionResult Index()
+        {
+            return View();
+        }
+        
+        public IActionResult Attractions()
         {
             return View();
         }

--- a/NeverNeverLand/Controllers/ParkPassesController.cs
+++ b/NeverNeverLand/Controllers/ParkPassesController.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.NetworkInformation;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using NeverNeverLand.Data;
 using NeverNeverLand.Models;
+using NeverNeverLand.Models.ViewModels;
 using NeverNeverLand.Services;
 using Stripe;
 

--- a/NeverNeverLand/Controllers/ParkPassesController.cs
+++ b/NeverNeverLand/Controllers/ParkPassesController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net.NetworkInformation;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -30,41 +29,47 @@ namespace NeverNeverLand.Controllers
 
         public IActionResult Index()
         {
-            var p = _pricing.GetCurrentPrices();
+            var seasonName = _pricing.GetCurrentSeasonName();
+            var personalPrice = _pricing.GetCurrentPrices("Personal");
+            var familyPrice = _pricing.GetCurrentPrices("Family");
+            var familyPlusPrice = _pricing.GetCurrentPrices("Family+");
 
             var vm = new PassViewModel
             {
-                PhaseLabel = p.SeasonName,
+                PhaseLabel = seasonName,
                 Blurb = "Same benefits across all passes — coverage size is the only difference.",
-                CurrentPrice = p.Personal,
-                PersonalPrice = p.Personal,
-                FamilyPrice = p.Family,
-                FamilyPlusPrice = p.FamilyPlus
+                CurrentPrice = personalPrice,
+                PersonalPrice = personalPrice,
+                FamilyPrice = familyPrice,
+                FamilyPlusPrice = familyPlusPrice
             };
             return View(vm);
         }
 
         public IActionResult Buy(string type = "Personal")
         {
-            var p = _pricing.GetCurrentPrices();
+            var seasonName = _pricing.GetCurrentSeasonName();
+            var personalPrice = _pricing.GetCurrentPrices("Personal");
+            var familyPrice = _pricing.GetCurrentPrices("Family");
+            var familyPlusPrice = _pricing.GetCurrentPrices("Family+");
             var normalized = NormalizePassType(type) ?? "Personal";
 
             var selectedPrice = normalized switch
             {
-                "Family" => p.Family,
-                "Family+" => p.FamilyPlus,
-                _ => p.Personal
+                "Family" => familyPrice,
+                "Family+" => familyPlusPrice,
+                _ => personalPrice
             };
 
             var vm = new PassBuyViewModel
             {
-                PhaseLabel = p.SeasonName,
+                PhaseLabel = seasonName,
                 PublishableKey = _stripe.PublishableKey,
                 SelectedPassType = normalized,
                 CurrentPrice = selectedPrice,
-                PersonalPrice = p.Personal,
-                FamilyPrice = p.Family,
-                FamilyPlusPrice = p.FamilyPlus,
+                PersonalPrice = personalPrice,
+                FamilyPrice = familyPrice,
+                FamilyPlusPrice = familyPlusPrice,
                 PassTypes = new[] { "Personal", "Family", "Family+" }
             };
 
@@ -81,17 +86,19 @@ namespace NeverNeverLand.Controllers
             var type = NormalizePassType(req.PassType);
             if (type is null) return BadRequest("Unknown pass type.");
 
-            var prices = _pricing.GetCurrentPrices();
+            var seasonName = _pricing.GetCurrentSeasonName();
+            var personalPrice = _pricing.GetCurrentPrices("Personal");
+            var familyPrice = _pricing.GetCurrentPrices("Family");
+            var familyPlusPrice = _pricing.GetCurrentPrices("Family+");
             decimal selectedPrice = type switch
             {
-                "Personal" => prices.Personal,
-                "Family" => prices.Family,
-                "Family+" => prices.FamilyPlus,
-                _ => prices.Personal
+                "Personal" => personalPrice,
+                "Family" => familyPrice,
+                "Family+" => familyPlusPrice,
+                _ => personalPrice
             };
             if (selectedPrice <= 0) return BadRequest("Price not available.");
 
-            // UPDATED rules: Personal=1/2, Family=2/4, Family+=2/7
             var policy = GetPolicyFor(type);
 
             StripeConfiguration.ApiKey = _stripe.SecretKey;
@@ -103,12 +110,12 @@ namespace NeverNeverLand.Controllers
                 Currency = "usd",
                 AutomaticPaymentMethods = new PaymentIntentAutomaticPaymentMethodsOptions { Enabled = true },
                 ReceiptEmail = req.Email,
-                Description = $"{type} Season Pass ({prices.SeasonName})",
+                Description = $"{type} Season Pass ({seasonName})",
                 Metadata = new Dictionary<string, string>
                 {
                     ["nnl_item"] = "SeasonPass",
                     ["nnl_pass_type"] = type,
-                    ["nnl_season"] = prices.SeasonName,
+                    ["nnl_season"] = seasonName,
                     ["nnl_price_usd"] = selectedPrice.ToString("0.00"),
                     ["nnl_policy_maxOwners"] = policy.MaxOwners.ToString(),
                     ["nnl_policy_maxGuests"] = policy.MaxGuests.ToString()

--- a/NeverNeverLand/Data/ApplicationDbContext.cs
+++ b/NeverNeverLand/Data/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NeverNeverLand.Models;
 
 namespace NeverNeverLand.Data
@@ -10,7 +11,55 @@ namespace NeverNeverLand.Data
             : base(options)
         {
         }
+
+
         public DbSet<Models.Ticket> Ticket { get; set; }
         public DbSet<NeverNeverLand.Models.ParkPass> ParkPass { get; set; } = default!;
+        public DbSet<Price> Prices => Set<Price>();
+        public DbSet<PriceChangeLog> PriceChangeLogs => Set<PriceChangeLog>();
+        public DbSet<Season> Seasons => Set<Season>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            // DateOnly <-> date (SQL) conversion
+            var dateOnlyConverter = new ValueConverter<DateOnly, DateTime>(
+                d => d.ToDateTime(TimeOnly.MinValue),
+                d => DateOnly.FromDateTime(d));
+
+            modelBuilder.Entity<Season>(e =>
+            {
+                e.Property(s => s.Name).HasMaxLength(100).IsRequired();
+                e.Property(s => s.StartDate).HasConversion(dateOnlyConverter).HasColumnType("date");
+                e.Property(s => s.EndDate).HasConversion(dateOnlyConverter).HasColumnType("date");
+
+                e.HasIndex(s => new { s.IsActive, s.AlwaysOn, s.StartDate, s.EndDate });
+            });
+
+            modelBuilder.Entity<Price>(e =>
+            {
+                e.Property(p => p.Amount).HasColumnType("decimal(10,2)");
+                e.Property(p => p.AdmissionType).HasMaxLength(50);
+                e.Property(p => p.Channel).HasMaxLength(16);
+                e.Property(p => p.Currency).HasMaxLength(3);
+
+                e.HasOne(p => p.Season).WithMany().HasForeignKey(p => p.SeasonId).OnDelete(DeleteBehavior.Restrict);
+
+                
+                e.HasIndex(p => new { p.SeasonId, p.AdmissionType, p.Channel, p.IsActive });
+            });
+
+            modelBuilder.Entity<PriceChangeLog>(e =>
+            {
+                e.Property(x => x.OldAmount).HasColumnType("decimal(10,2)");
+                e.Property(x => x.NewAmount).HasColumnType("decimal(10,2)");
+            });
+
+            modelBuilder.Entity<Ticket>(e =>
+            {
+                e.Property(x => x.PricePaid).HasColumnType("decimal(10,2)");
+            });
+        }
     }
 }

--- a/NeverNeverLand/Data/ApplicationDbContext.cs
+++ b/NeverNeverLand/Data/ApplicationDbContext.cs
@@ -40,15 +40,20 @@ namespace NeverNeverLand.Data
             modelBuilder.Entity<Price>(e =>
             {
                 e.Property(p => p.Amount).HasColumnType("decimal(10,2)");
-                e.Property(p => p.AdmissionType).HasMaxLength(50);
-                e.Property(p => p.Channel).HasMaxLength(16);
                 e.Property(p => p.Currency).HasMaxLength(3);
+                e.Property(p => p.Kind).HasMaxLength(16);
+                e.Property(p => p.Item).HasMaxLength(64);
+                e.Property(p => p.Channel).HasMaxLength(16);
 
-                e.HasOne(p => p.Season).WithMany().HasForeignKey(p => p.SeasonId).OnDelete(DeleteBehavior.Restrict);
+                e.HasOne(p => p.Season)
+                 .WithMany()
+                 .HasForeignKey(p => p.SeasonId)
+                 .OnDelete(DeleteBehavior.Restrict);
 
-                
-                e.HasIndex(p => new { p.SeasonId, p.AdmissionType, p.Channel, p.IsActive });
+                // unique-ish index
+                e.HasIndex(p => new { p.SeasonId, p.Kind, p.Item, p.Channel, p.IsActive });
             });
+
 
             modelBuilder.Entity<PriceChangeLog>(e =>
             {

--- a/NeverNeverLand/Data/Migrations/20250822191144_PriceLogFix.Designer.cs
+++ b/NeverNeverLand/Data/Migrations/20250822191144_PriceLogFix.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NeverNeverLand.Data;
 
@@ -11,9 +12,11 @@ using NeverNeverLand.Data;
 namespace NeverNeverLand.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250822191144_PriceLogFix")]
+    partial class PriceLogFix
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -275,11 +278,6 @@ namespace NeverNeverLand.Data.Migrations
                     b.Property<decimal>("Amount")
                         .HasColumnType("decimal(10,2)");
 
-                    b.Property<string>("Channel")
-                        .IsRequired()
-                        .HasMaxLength(16)
-                        .HasColumnType("nvarchar(16)");
-
                     b.Property<string>("Currency")
                         .IsRequired()
                         .HasMaxLength(3)
@@ -299,7 +297,7 @@ namespace NeverNeverLand.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("SeasonId", "AdmissionType", "Channel", "IsActive");
+                    b.HasIndex("SeasonId", "AdmissionType", "IsActive");
 
                     b.ToTable("Prices");
                 });

--- a/NeverNeverLand/Data/Migrations/20250822191144_PriceLogFix.cs
+++ b/NeverNeverLand/Data/Migrations/20250822191144_PriceLogFix.cs
@@ -1,0 +1,305 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NeverNeverLand.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class PriceLogFix : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "ParkPass");
+
+            migrationBuilder.DropColumn(
+                name: "Price",
+                table: "ParkPass");
+
+            migrationBuilder.DropColumn(
+                name: "ValidFrom",
+                table: "ParkPass");
+
+            migrationBuilder.RenameColumn(
+                name: "ValidUntil",
+                table: "ParkPass",
+                newName: "ExpiresAt");
+
+            migrationBuilder.RenameColumn(
+                name: "Name",
+                table: "ParkPass",
+                newName: "Type");
+
+            migrationBuilder.RenameColumn(
+                name: "Description",
+                table: "ParkPass",
+                newName: "Status");
+
+            migrationBuilder.AddColumn<string>(
+                name: "AdmissionType",
+                table: "Ticket",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Currency",
+                table: "Ticket",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "HolderAge",
+                table: "Ticket",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HolderName",
+                table: "Ticket",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "PricePaid",
+                table: "Ticket",
+                type: "decimal(10,2)",
+                nullable: false,
+                defaultValue: 0m);
+
+            // 🔽 Fix: drop and recreate ParkPass.Id as GUID instead of AlterColumn
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ParkPass",
+                table: "ParkPass");
+
+            migrationBuilder.DropColumn(
+                name: "Id",
+                table: "ParkPass");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "Id",
+                table: "ParkPass",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValueSql: "NEWID()");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ParkPass",
+                table: "ParkPass",
+                column: "Id");
+
+            migrationBuilder.AddColumn<int>(
+                name: "MaxGuests",
+                table: "ParkPass",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MaxOwners",
+                table: "ParkPass",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "QrToken",
+                table: "ParkPass",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "SeasonYear",
+                table: "ParkPass",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "PriceChangeLogs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    TicketId = table.Column<int>(type: "int", nullable: false),
+                    SeasonId = table.Column<int>(type: "int", nullable: true),
+                    ChangedByUserId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ChangedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    OldAmount = table.Column<decimal>(type: "decimal(10,2)", nullable: false),
+                    NewAmount = table.Column<decimal>(type: "decimal(10,2)", nullable: false),
+                    Currency = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Note = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PriceChangeLogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Seasons",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    StartDate = table.Column<DateTime>(type: "date", nullable: true),
+                    EndDate = table.Column<DateTime>(type: "date", nullable: true),
+                    AlwaysOn = table.Column<bool>(type: "bit", nullable: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Seasons", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Prices",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    SeasonId = table.Column<int>(type: "int", nullable: false),
+                    AdmissionType = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Amount = table.Column<decimal>(type: "decimal(10,2)", nullable: false),
+                    Currency = table.Column<string>(type: "nvarchar(3)", maxLength: 3, nullable: false),
+                    EffectiveStartUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    EffectiveEndUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Prices", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Prices_Seasons_SeasonId",
+                        column: x => x.SeasonId,
+                        principalTable: "Seasons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Prices_SeasonId_AdmissionType_IsActive",
+                table: "Prices",
+                columns: new[] { "SeasonId", "AdmissionType", "IsActive" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Seasons_IsActive_AlwaysOn_StartDate_EndDate",
+                table: "Seasons",
+                columns: new[] { "IsActive", "AlwaysOn", "StartDate", "EndDate" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PriceChangeLogs");
+
+            migrationBuilder.DropTable(
+                name: "Prices");
+
+            migrationBuilder.DropTable(
+                name: "Seasons");
+
+            migrationBuilder.DropColumn(
+                name: "AdmissionType",
+                table: "Ticket");
+
+            migrationBuilder.DropColumn(
+                name: "Currency",
+                table: "Ticket");
+
+            migrationBuilder.DropColumn(
+                name: "HolderAge",
+                table: "Ticket");
+
+            migrationBuilder.DropColumn(
+                name: "HolderName",
+                table: "Ticket");
+
+            migrationBuilder.DropColumn(
+                name: "PricePaid",
+                table: "Ticket");
+
+            migrationBuilder.DropColumn(
+                name: "MaxGuests",
+                table: "ParkPass");
+
+            migrationBuilder.DropColumn(
+                name: "MaxOwners",
+                table: "ParkPass");
+
+            migrationBuilder.DropColumn(
+                name: "QrToken",
+                table: "ParkPass");
+
+            migrationBuilder.DropColumn(
+                name: "SeasonYear",
+                table: "ParkPass");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ParkPass",
+                table: "ParkPass");
+
+            migrationBuilder.DropColumn(
+                name: "Id",
+                table: "ParkPass");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Id",
+                table: "ParkPass",
+                type: "int",
+                nullable: false)
+                .Annotation("SqlServer:Identity", "1, 1");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ParkPass",
+                table: "ParkPass",
+                column: "Id");
+
+            migrationBuilder.RenameColumn(
+                name: "Type",
+                table: "ParkPass",
+                newName: "Name");
+
+            migrationBuilder.RenameColumn(
+                name: "Status",
+                table: "ParkPass",
+                newName: "Description");
+
+            migrationBuilder.RenameColumn(
+                name: "ExpiresAt",
+                table: "ParkPass",
+                newName: "ValidUntil");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "ParkPass",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "Price",
+                table: "ParkPass",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ValidFrom",
+                table: "ParkPass",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/NeverNeverLand/Data/Migrations/20250824053459_addedChannel.Designer.cs
+++ b/NeverNeverLand/Data/Migrations/20250824053459_addedChannel.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NeverNeverLand.Data;
 
@@ -11,9 +12,11 @@ using NeverNeverLand.Data;
 namespace NeverNeverLand.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250824053459_addedChannel")]
+    partial class addedChannel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/NeverNeverLand/Data/Migrations/20250824053459_addedChannel.cs
+++ b/NeverNeverLand/Data/Migrations/20250824053459_addedChannel.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NeverNeverLand.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class addedChannel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Prices_SeasonId_AdmissionType_IsActive",
+                table: "Prices");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Channel",
+                table: "Prices",
+                type: "nvarchar(16)",
+                maxLength: 16,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Prices_SeasonId_AdmissionType_Channel_IsActive",
+                table: "Prices",
+                columns: new[] { "SeasonId", "AdmissionType", "Channel", "IsActive" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Prices_SeasonId_AdmissionType_Channel_IsActive",
+                table: "Prices");
+
+            migrationBuilder.DropColumn(
+                name: "Channel",
+                table: "Prices");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Prices_SeasonId_AdmissionType_IsActive",
+                table: "Prices",
+                columns: new[] { "SeasonId", "AdmissionType", "IsActive" });
+        }
+    }
+}

--- a/NeverNeverLand/Data/Migrations/20250825180809_PriceDataTest.Designer.cs
+++ b/NeverNeverLand/Data/Migrations/20250825180809_PriceDataTest.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NeverNeverLand.Data;
 
@@ -11,9 +12,11 @@ using NeverNeverLand.Data;
 namespace NeverNeverLand.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250825180809_PriceDataTest")]
+    partial class PriceDataTest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/NeverNeverLand/Data/Migrations/20250825180809_PriceDataTest.cs
+++ b/NeverNeverLand/Data/Migrations/20250825180809_PriceDataTest.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NeverNeverLand.Data.Migrations
+{
+    public partial class PriceDataTest : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // 1) Add new columns first
+            migrationBuilder.AddColumn<string>(
+                name: "Item",
+                table: "Prices",
+                type: "nvarchar(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Kind",
+                table: "Prices",
+                type: "nvarchar(16)",
+                maxLength: 16,
+                nullable: false,
+                defaultValue: "Ticket"); // sensible default
+
+            // 2) Backfill data from AdmissionType -> Item, set Kind='Ticket'
+            migrationBuilder.Sql(@"
+                UPDATE P
+                SET 
+                    Kind = CASE WHEN ISNULL(Kind,'') = '' THEN 'Ticket' ELSE Kind END,
+                    Item = CASE 
+                               WHEN ISNULL(Item,'') = '' THEN ISNULL(AdmissionType,'') 
+                               ELSE Item 
+                           END
+                FROM Prices AS P;
+            ");
+
+            // 3) Drop old index that references AdmissionType (if it exists)
+            migrationBuilder.Sql(@"
+                IF EXISTS (SELECT 1 FROM sys.indexes 
+                          WHERE name = 'IX_Prices_SeasonId_AdmissionType_Channel_IsActive' 
+                            AND object_id = OBJECT_ID('Prices'))
+                BEGIN
+                    DROP INDEX IX_Prices_SeasonId_AdmissionType_Channel_IsActive ON Prices;
+                END
+            ");
+
+            // 4) Create the new composite index
+            migrationBuilder.CreateIndex(
+                name: "IX_Prices_SeasonId_Kind_Item_Channel_IsActive",
+                table: "Prices",
+                columns: new[] { "SeasonId", "Kind", "Item", "Channel", "IsActive" });
+
+            // 5) Only now drop the legacy column
+            migrationBuilder.DropColumn(
+                name: "AdmissionType",
+                table: "Prices");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // 1) Recreate old column
+            migrationBuilder.AddColumn<string>(
+                name: "AdmissionType",
+                table: "Prices",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+
+            // 2) Backfill AdmissionType from Item when Kind='Ticket'
+            migrationBuilder.Sql(@"
+                UPDATE P
+                SET AdmissionType = CASE 
+                    WHEN ISNULL(Item,'') <> '' AND Kind = 'Ticket' THEN Item 
+                    ELSE ''
+                END
+                FROM Prices AS P;
+            ");
+
+            // 3) Drop new index
+            migrationBuilder.Sql(@"
+                IF EXISTS (SELECT 1 FROM sys.indexes 
+                          WHERE name = 'IX_Prices_SeasonId_Kind_Item_Channel_IsActive' 
+                            AND object_id = OBJECT_ID('Prices'))
+                BEGIN
+                    DROP INDEX IX_Prices_SeasonId_Kind_Item_Channel_IsActive ON Prices;
+                END
+            ");
+
+            // 4) Restore old index
+            migrationBuilder.CreateIndex(
+                name: "IX_Prices_SeasonId_AdmissionType_Channel_IsActive",
+                table: "Prices",
+                columns: new[] { "SeasonId", "AdmissionType", "Channel", "IsActive" });
+
+            // 5) Optionally drop new columns (if you want a true rollback)
+            migrationBuilder.DropColumn(name: "Item", table: "Prices");
+            migrationBuilder.DropColumn(name: "Kind", table: "Prices");
+        }
+    }
+}

--- a/NeverNeverLand/Models/Helpers/AdmissionHelper.cs
+++ b/NeverNeverLand/Models/Helpers/AdmissionHelper.cs
@@ -1,0 +1,12 @@
+﻿namespace NeverNeverLand.Models.Helpers
+{
+    public static class AdmissionHelper
+    {
+        public static string GetAdmissionType(int age)
+        {
+            if (age < 3) return "Infant";   // could be free
+            if (age <= 17) return "Child";
+            return "Adult";
+        }
+    }
+}

--- a/NeverNeverLand/Models/ParkPass.cs
+++ b/NeverNeverLand/Models/ParkPass.cs
@@ -9,7 +9,7 @@
         public string Status { get; set; } = "Active";
         public string QrToken { get; set; } = Guid.NewGuid().ToString("N");
 
-        public int MaxOwners { get; set; } // Personal=1, Family=2, Family+=2
-        public int MaxGuests { get; set; } // Personal=2, Family=4, Family+=7
+        public int MaxOwners { get; set; } = 1; // Personal=1, Family=2, Family+=2 (default at personal)
+        public int MaxGuests { get; set; } = 2; // Personal=2, Family=4, Family+=7 (default at personal)
     }
 }

--- a/NeverNeverLand/Models/Price.cs
+++ b/NeverNeverLand/Models/Price.cs
@@ -1,0 +1,24 @@
+﻿using System.Net.Sockets;
+
+namespace NeverNeverLand.Models
+{
+    public class Price
+    {
+        public int Id { get; set; }
+
+        public int SeasonId { get; set; }
+        public Season Season { get; set; } = null!;
+
+        public string AdmissionType { get; set; } = ""; // e.g., "Adult", "Child",  probably in the future add "Senior"
+        public string Channel { get; set; } = "Online";      // "Online" or "Gate"
+
+        public decimal Amount { get; set; }
+        public string Currency { get; set; } = "USD";
+
+        public DateTime? EffectiveStartUtc { get; set; }
+        public DateTime? EffectiveEndUtc { get; set; }
+
+        public bool IsActive { get; set; } = true;
+    }
+
+}

--- a/NeverNeverLand/Models/Price.cs
+++ b/NeverNeverLand/Models/Price.cs
@@ -1,6 +1,4 @@
-﻿using System.Net.Sockets;
-
-namespace NeverNeverLand.Models
+﻿namespace NeverNeverLand.Models
 {
     public class Price
     {
@@ -9,16 +7,20 @@ namespace NeverNeverLand.Models
         public int SeasonId { get; set; }
         public Season Season { get; set; } = null!;
 
-        public string AdmissionType { get; set; } = ""; // e.g., "Adult", "Child",  probably in the future add "Senior"
-        public string Channel { get; set; } = "Online";      // "Online" or "Gate"
+        // "Ticket", "Pass", "Product"
+        public string Kind { get; set; } = "Ticket";
+
+        // Variant, e.g. "Adult", "Child", "PersonalPass", "Hoodie"
+        public string Item { get; set; } = "";
+
+        // Where it’s sold
+        public string Channel { get; set; } = "Online"; // "Online" or "Gate"
 
         public decimal Amount { get; set; }
         public string Currency { get; set; } = "USD";
 
         public DateTime? EffectiveStartUtc { get; set; }
         public DateTime? EffectiveEndUtc { get; set; }
-
         public bool IsActive { get; set; } = true;
     }
-
 }

--- a/NeverNeverLand/Models/PriceChangeLog.cs
+++ b/NeverNeverLand/Models/PriceChangeLog.cs
@@ -1,0 +1,22 @@
+﻿namespace NeverNeverLand.Models
+{
+    public class PriceChangeLog
+    {
+        public int Id { get; set; }
+
+        // Context of the change
+        public int TicketId { get; set; }         // which ticket this price applied to
+        public int? SeasonId { get; set; }        // which season (nullable if AlwaysOn/default)
+
+        // Audit info
+        public string ChangedByUserId { get; set; } = "";
+        public DateTime ChangedAtUtc { get; set; } = DateTime.UtcNow;
+
+        // Before/after snapshot
+        public decimal OldAmount { get; set; }
+        public decimal NewAmount { get; set; }
+        public string Currency { get; set; } = "USD";
+
+        public string? Note { get; set; }
+    }
+}

--- a/NeverNeverLand/Models/Season.cs
+++ b/NeverNeverLand/Models/Season.cs
@@ -1,0 +1,12 @@
+﻿namespace NeverNeverLand.Models
+{
+    public class Season
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public DateOnly? StartDate { get; set; }
+        public DateOnly? EndDate { get; set; }
+        public bool AlwaysOn { get; set; }
+        public bool IsActive { get; set; } = true;
+    }
+}

--- a/NeverNeverLand/Models/Ticket.cs
+++ b/NeverNeverLand/Models/Ticket.cs
@@ -1,13 +1,31 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Composition.Convention;
 
 namespace NeverNeverLand.Models
 {
     public class Ticket
     {
+        [Key]
         public int TicketId { get; set; }
 
+        // This ties the purchase back to the buyer's account (parent/guardian)
         [Required]
-        public required string UserId { get; set; }
+        public string UserId { get; set; } = ""; 
+
+        // Info about the actual ticket holder
+        [Required, MaxLength(100)]
+        public string HolderName { get; set; } = "";   
+
+        [Range(0, 120)]
+        public int HolderAge { get; set; }             // used to validate Child/Adult pricing
+
+        [Required, MaxLength(50)]
+        public string AdmissionType { get; set; } = ""; // "Adult", "Child"
+
+        [DataType(DataType.Currency)]
+        public decimal PricePaid { get; set; } // for keeping records of what was paid
+
+        public string Currency { get; set; } = "USD";
 
         [DataType(DataType.DateTime)]
         public DateTime PurchaseDate { get; set; }

--- a/NeverNeverLand/Models/ViewModels/AdminPricingViewModel.cs
+++ b/NeverNeverLand/Models/ViewModels/AdminPricingViewModel.cs
@@ -1,0 +1,22 @@
+﻿namespace NeverNeverLand.Models.ViewModels
+{
+    using System.ComponentModel.DataAnnotations;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+
+    public class AdminPricingViewModel
+    {
+        // Form fields
+        [Required] public int SelectedSeasonId { get; set; }
+        [Required] public string SelectedAdmissionType { get; set; } = "Adult";
+        [Range(0, 999999)] public decimal Amount { get; set; }
+        [Required, StringLength(3)] public string Currency { get; set; } = "USD";
+
+        // Dropdown data
+        public List<SelectListItem> SeasonOptions { get; set; } = new();
+        public List<SelectListItem> AdmissionTypeOptions { get; set; } = new();
+
+
+        // Table data
+        public List<Price> Prices { get; set; } = new();
+    }
+}

--- a/NeverNeverLand/Models/ViewModels/ErrorViewModel.cs
+++ b/NeverNeverLand/Models/ViewModels/ErrorViewModel.cs
@@ -1,4 +1,4 @@
-namespace NeverNeverLand.Models
+namespace NeverNeverLand.Models.ViewModels
 {
     public class ErrorViewModel
     {

--- a/NeverNeverLand/Models/ViewModels/PassBuyViewModel.cs
+++ b/NeverNeverLand/Models/ViewModels/PassBuyViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace NeverNeverLand.Models
+﻿namespace NeverNeverLand.Models.ViewModels
 {
     public class PassBuyViewModel
     {

--- a/NeverNeverLand/Models/ViewModels/PassViewModel.cs
+++ b/NeverNeverLand/Models/ViewModels/PassViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace NeverNeverLand.Models
+﻿namespace NeverNeverLand.Models.ViewModels
 {
     public class PassViewModel
     {

--- a/NeverNeverLand/Models/ViewModels/TicketPurchaseViewModel.cs
+++ b/NeverNeverLand/Models/ViewModels/TicketPurchaseViewModel.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace NeverNeverLand.Models.ViewModels
+{
+    public class TicketPurchaseViewModel
+    {
+        [Required]
+        public string HolderName { get; set; } = "";
+
+        [Range(0, 120)]
+        public int HolderAge { get; set; }
+
+        // Calculated during purchase
+        public string AdmissionType { get; set; } = "";
+        public decimal PricePaid { get; set; }
+    }
+
+}

--- a/NeverNeverLand/Services/IPriceService.cs
+++ b/NeverNeverLand/Services/IPriceService.cs
@@ -1,9 +1,8 @@
 ﻿namespace NeverNeverLand.Services
 {
-    public record PassPrices(decimal Personal, decimal Family, decimal FamilyPlus, string SeasonName);
-
     public interface IPriceService
     {
-        PassPrices GetCurrentPrices(DateTime? nowUtc = null);
+        decimal GetCurrentPrices(string item, string channel = "Online", DateTime? nowUtc = null);
+        string GetCurrentSeasonName(DateTime? nowUtc = null);
     }
 }

--- a/NeverNeverLand/Services/PriceService.cs
+++ b/NeverNeverLand/Services/PriceService.cs
@@ -1,91 +1,77 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using NeverNeverLand.Data;
 
 namespace NeverNeverLand.Services
 {
-    internal class SeasonConfig
-    {
-        public string Name { get; set; } = "";
-        public string Start { get; set; } = ""; // "MM-dd"
-        public string End { get; set; } = ""; // "MM-dd"
-        public Dictionary<string, decimal> Prices { get; set; } = new();
-    }
-
     public class PriceService : IPriceService
     {
-        private readonly List<SeasonConfig> _seasons;
+        private readonly ApplicationDbContext _db;
         private readonly TimeZoneInfo _tz;
 
-        public PriceService(IConfiguration config)
+        public PriceService(ApplicationDbContext db, IConfiguration config)
         {
-            var section = config.GetSection("Pricing");
-            var tzId = section.GetValue<string>("TimeZone") ?? "America/Los_Angeles";
+            _db = db;
+            var tzId = config.GetSection("Pricing").GetValue<string>("TimeZone") ?? "America/Los_Angeles";
             _tz = TimeZoneInfo.FindSystemTimeZoneById(tzId);
-
-            _seasons = section.GetSection("Seasons").Get<List<SeasonConfig>>() ?? new();
         }
 
-        public PassPrices GetCurrentPrices(DateTime? nowUtc = null)
+        public string GetCurrentSeasonName(DateTime? nowUtc = null)
         {
-            var nowLocal = TimeZoneInfo.ConvertTimeFromUtc(nowUtc ?? DateTime.UtcNow, _tz);
-            var season = ResolveSeason(nowLocal);
-
-            decimal Get(string key) => season.Prices.TryGetValue(key, out var v) ? v : 0m;
-
-            return new PassPrices(
-                Personal: Get("Personal"),
-                Family: Get("Family"),
-                FamilyPlus: Get("FamilyPlus"),
-                SeasonName: season.Name
-            );
+            var season = ResolveSeason(nowUtc);
+            return season.Name;
         }
 
-        private SeasonConfig ResolveSeason(DateTime localNow)
+        public decimal GetCurrentPrices(string item, string channel = "Online", DateTime? nowUtc = null)
         {
-            SeasonConfig? fallbackClosest = null;
-            TimeSpan? bestDistance = null;
+            var season = ResolveSeason(nowUtc);
 
-            foreach (var s in _seasons)
+            // try exact item first (e.g., "Family+")
+            var amount = _db.Prices.AsNoTracking()
+                .Where(p => p.SeasonId == season.Id && p.Kind == "Pass" && p.Item == item
+                            && p.Channel == channel && p.IsActive)
+                .OrderByDescending(p => p.EffectiveStartUtc)
+                .Select(p => p.Amount)
+                .FirstOrDefault();
+
+            if (amount > 0m) return amount;
+
+            // fallback if DB used "FamilyPlus" instead of "Family+"
+            if (string.Equals(item, "Family+", StringComparison.OrdinalIgnoreCase))
             {
-                var (start, end) = BuildSeasonRange(localNow, s.Start, s.End);
-
-                if (localNow.Date >= start.Date && localNow.Date <= end.Date)
-                    return s;
-
-                var distance = (localNow - start).Duration();
-                if (bestDistance is null || distance < bestDistance.Value)
-                {
-                    bestDistance = distance;
-                    fallbackClosest = s;
-                }
+                amount = _db.Prices.AsNoTracking()
+                    .Where(p => p.SeasonId == season.Id && p.Kind == "Pass" && p.Item == "FamilyPlus"
+                                && p.Channel == channel && p.IsActive)
+                    .OrderByDescending(p => p.EffectiveStartUtc)
+                    .Select(p => p.Amount)
+                    .FirstOrDefault();
             }
 
-            return fallbackClosest ?? (_seasons.Count > 0 ? _seasons[0] : new SeasonConfig
-            {
-                Name = "Unknown",
-                Start = "01-01",
-                End = "12-31",
-                Prices = new() { ["Personal"] = 0, ["Family"] = 0, ["FamilyPlus"] = 0 }
-            });
+            if (amount <= 0m)
+                throw new InvalidOperationException($"No active price for pass '{item}' ({channel}) in season '{season.Name}'.");
+
+            return amount;
         }
 
-        private static (DateTime start, DateTime end) BuildSeasonRange(DateTime pivot, string startMd, string endMd)
+        private Models.Season ResolveSeason(DateTime? nowUtc)
         {
-            var s = DateTime.ParseExact(startMd, "MM-dd", null);
-            var e = DateTime.ParseExact(endMd, "MM-dd", null);
+            var localNow = TimeZoneInfo.ConvertTimeFromUtc(nowUtc ?? DateTime.UtcNow, _tz);
+            var today = DateOnly.FromDateTime(localNow);
 
-            var start = new DateTime(pivot.Year, s.Month, s.Day);
-            var end = new DateTime(pivot.Year, e.Month, e.Day);
+            var season = _db.Seasons.AsNoTracking()
+                .Where(s => s.IsActive &&
+                            (s.AlwaysOn ||
+                             (s.StartDate <= today && (s.EndDate == null || s.EndDate >= today))))
+                .OrderByDescending(s => !s.AlwaysOn) // prefer dated over AlwaysOn
+                .ThenBy(s => s.StartDate)
+                .FirstOrDefault();
 
-            if (end < start)
-            {
-                if (pivot.Month < start.Month)
-                    start = new DateTime(pivot.Year - 1, s.Month, s.Day);
-                else
-                    end = new DateTime(pivot.Year + 1, e.Month, e.Day);
-            }
+            if (season == null)
+                throw new InvalidOperationException("No active season configured.");
 
-            end = end.Date.AddDays(1).AddTicks(-1); // inclusive
-            return (start, end);
+            return season;
         }
     }
 }

--- a/NeverNeverLand/Views/Admin/Index.cshtml
+++ b/NeverNeverLand/Views/Admin/Index.cshtml
@@ -1,0 +1,92 @@
+﻿@using NeverNeverLand.Models.ViewModels
+@model AdminPricingViewModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+@{
+    ViewData["Title"] = "Pricing Admin";
+}
+
+<h2 class="mb-3">Pricing Admin</h2>
+
+<div class="card mb-4">
+    <div class="card-header">Create / Update Price</div>
+    <div class="card-body">
+        <form asp-action="CreatePrice" method="post">
+            <div class="row g-3 align-items-end">
+                <div class="col-md-4">
+                    <label asp-for="SelectedSeasonId" class="form-label"></label>
+                    <select asp-for="SelectedSeasonId" asp-items="Model.SeasonOptions" class="form-select"></select>
+                    <span asp-validation-for="SelectedSeasonId" class="text-danger"></span>
+                </div>
+                <label asp-for="SelectedAdmissionType" class="form-label"></label>
+                <select asp-for="SelectedAdmissionType"
+                        asp-items="Model.AdmissionTypeOptions"
+                        class="form-select"></select>
+                <span asp-validation-for="SelectedAdmissionType" class="text-danger"></span>
+                <div class="col-md-2">
+                    <label asp-for="Amount" class="form-label"></label>
+                    <input asp-for="Amount" class="form-control" />
+                    <span asp-validation-for="Amount" class="text-danger"></span>
+                </div>
+                <div class="col-md-1">
+                    <label asp-for="Currency" class="form-label"></label>
+                    <input asp-for="Currency" class="form-control" />
+                    <span asp-validation-for="Currency" class="text-danger"></span>
+                </div>
+                <div class="col-md-1">
+                    <button class="btn btn-primary w-100" type="submit">Save</button>
+                </div>
+            </div>
+        </form>
+        <small class="text-muted d-block mt-2">
+            Saving will deactivate any existing active price for the selected Season/Ticket pair and create a new one.
+        </small>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header">Prices</div>
+    <div class="card-body p-0">
+        <table class="table table-striped table-hover mb-0">
+            <thead>
+                <tr>
+                    <th>Season</th>
+                    <th>Ticket</th>
+                    <th class="text-end">Amount</th>
+                    <th>Currency</th>
+                    <th>Effective Start</th>
+                    <th>Effective End</th>
+                    <th>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var p in Model.Prices)
+                {
+                    <tr>
+                        <td>@p.Season?.Name</td>
+                        <td>@p.AdmissionType</td>
+                        <td class="text-end">@p.Amount.ToString("0.00")</td>
+                        <td>@p.Currency</td>
+                        <td>@(p.EffectiveStartUtc?.ToLocalTime().ToString("g") ?? "-")</td>
+                        <td>@(p.EffectiveEndUtc?.ToLocalTime().ToString("g") ?? "-")</td>
+                        <td>
+                            @if (p.IsActive)
+                            {
+                                <span class="badge bg-success">Active</span>
+                            }
+                            else
+                            {
+
+                                <span class="badge bg-secondary">Inactive</span>
+                            }
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/NeverNeverLand/Views/Admin/Index.cshtml
+++ b/NeverNeverLand/Views/Admin/Index.cshtml
@@ -64,7 +64,7 @@
                 {
                     <tr>
                         <td>@p.Season?.Name</td>
-                        <td>@p.AdmissionType</td>
+                        <td>@p.Item</td>
                         <td class="text-end">@p.Amount.ToString("0.00")</td>
                         <td>@p.Currency</td>
                         <td>@(p.EffectiveStartUtc?.ToLocalTime().ToString("g") ?? "-")</td>

--- a/NeverNeverLand/Views/Home/Attractions.cshtml
+++ b/NeverNeverLand/Views/Home/Attractions.cshtml
@@ -1,0 +1,140 @@
+﻿@{
+    ViewData["Title"] = "Attractions";
+}
+
+<div class="container my-5">
+
+    <!-- Hero -->
+    <div class="position-relative overflow-hidden rounded-4 shadow-sm mb-4"
+         style="background:url('/images/attractions/banner-forest.jpg') center/cover; min-height:260px;">
+        <div class="position-absolute top-0 start-0 w-100 h-100" style="background:rgba(0,0,0,.35);"></div>
+        <div class="position-absolute top-50 start-50 translate-middle text-white text-center px-3">
+            <h1 class="display-6 fw-bold">Never Never Land Attractions</h1>
+            <p class="lead mb-0">Classic storybook fun brought back to life.</p>
+        </div>
+    </div>
+
+    <!-- Two Slides -->
+    <section class="my-4">
+        <h2 class="h4 mb-3">Featured Slides</h2>
+        <div class="row g-4">
+            <!-- Crooked Old Man’s House -->
+            <div class="col-md-6">
+                <div class="card h-100 border-0 shadow-sm rounded-4">
+                    <img src="/images/attractions/crooked-house.jpg"
+                         class="card-img-top rounded-top-4"
+                         alt="Crooked Old Man’s House maze and slide">
+                    <div class="card-body">
+                        <span class="badge bg-primary mb-2">Maze & Slide</span>
+                        <h3 class="h5">Crooked Old Man’s House</h3>
+                        <p class="mb-0 text-muted">
+                            Wind your way through the crooked cottage maze, then swoop down the restored slide.
+                            A fan favorite that brings the nursery rhyme to life.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Old Woman’s Shoe -->
+            <div class="col-md-6">
+                <div class="card h-100 border-0 shadow-sm rounded-4">
+                    <img src="/images/attractions/old-womans-shoe.jpg"
+                         class="card-img-top rounded-top-4"
+                         alt="Old Woman’s Shoe slide">
+                    <div class="card-body">
+                        <span class="badge bg-warning text-dark mb-2">Slide</span>
+                        <h3 class="h5">Old Woman’s Shoe</h3>
+                        <p class="mb-0 text-muted">
+                            Climb into the famous shoe and race your friends down the slide—simple, timeless fun.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Nursery Rhymes on Display -->
+    <section class="my-5">
+        <h2 class="h4 mb-3">Nursery Rhymes on Display</h2>
+        <p class="text-muted">
+            Explore classic figures and scenes throughout the park. Here are a few you’ll spot on your walk:
+        </p>
+
+        <div class="row g-4">
+            @* Use/duplicate these cards as needed; swap images & text *@
+
+            <div class="col-sm-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm rounded-4">
+                    <img src="/images/attractions/humpty-dumpty.jpg"
+                         class="card-img-top rounded-top-4"
+                         alt="Humpty Dumpty figure">
+                    <div class="card-body">
+                        <h3 class="h6 mb-1">Humpty Dumpty</h3>
+                        <p class="small text-muted mb-0">Perched on his wall—mind the fall!</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-sm-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm rounded-4">
+                    <img src="/images/attractions/little-miss-muffet.jpg"
+                         class="card-img-top rounded-top-4"
+                         alt="Little Miss Muffet display">
+                    <div class="card-body">
+                        <h3 class="h6 mb-1">Little Miss Muffet</h3>
+                        <p class="small text-muted mb-0">Curds, whey—and a surprise visitor.</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-sm-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm rounded-4">
+                    <img src="/images/attractions/old-woman-shoescene.jpg"
+                         class="card-img-top rounded-top-4"
+                         alt="There Was an Old Woman Who Lived in a Shoe display">
+                    <div class="card-body">
+                        <h3 class="h6 mb-1">Old Woman Who Lived in a Shoe</h3>
+                        <p class="small text-muted mb-0">The scene that inspired the slide.</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-sm-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm rounded-4">
+                    <img src="/images/attractions/cat-fiddle.jpg"
+                         class="card-img-top rounded-top-4"
+                         alt="Hey Diddle Diddle display">
+                    <div class="card-body">
+                        <h3 class="h6 mb-1">Hey Diddle Diddle</h3>
+                        <p class="small text-muted mb-0">Cow, moon, and a grinning cat.</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-sm-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm rounded-4">
+                    <img src="/images/attractions/jack-jill.jpg"
+                         class="card-img-top rounded-top-4"
+                         alt="Jack and Jill display">
+                    <div class="card-body">
+                        <h3 class="h6 mb-1">Jack and Jill</h3>
+                        <p class="small text-muted mb-0">Pails up the hill—tumbles optional.</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-sm-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm rounded-4">
+                    <img src="/images/attractions/baa-baa.jpg"
+                         class="card-img-top rounded-top-4"
+                         alt="Baa Baa Black Sheep display">
+                    <div class="card-body">
+                        <h3 class="h6 mb-1">Baa Baa Black Sheep</h3>
+                        <p class="small text-muted mb-0">Three bags full on market day.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+</div>

--- a/NeverNeverLand/Views/ParkPasses/Buy.cshtml
+++ b/NeverNeverLand/Views/ParkPasses/Buy.cshtml
@@ -1,4 +1,5 @@
-﻿@model NeverNeverLand.Models.PassBuyViewModel
+﻿@using NeverNeverLand.Models.ViewModels
+@model PassBuyViewModel
 @{
     ViewData["Title"] = "Buy Season Pass";
 }

--- a/NeverNeverLand/Views/ParkPasses/Index.cshtml
+++ b/NeverNeverLand/Views/ParkPasses/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@model PassViewModel
+﻿@using NeverNeverLand.Models.ViewModels
+@model PassViewModel
 @{
     ViewData["Title"] = "Season Pass";
 }

--- a/NeverNeverLand/Views/Shared/Error.cshtml
+++ b/NeverNeverLand/Views/Shared/Error.cshtml
@@ -1,4 +1,5 @@
-﻿@model ErrorViewModel
+﻿@using NeverNeverLand.Models.ViewModels
+@model ErrorViewModel
 @{
     ViewData["Title"] = "Error";
 }

--- a/NeverNeverLand/Views/Shared/_Layout.cshtml
+++ b/NeverNeverLand/Views/Shared/_Layout.cshtml
@@ -42,10 +42,10 @@
             <div class="collapse navbar-collapse" id="mainNav">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                     <li class="nav-item"><a class="nav-link" href="/">Home</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/Attractions">Attractions</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/Events">Events</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/About">About</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/Contact">Contact</a></li>
+                    <li class="nav-item"><a class="nav-link" asp-controller="Home" asp-action="Attractions">Attractions</a>
+                    <li class="nav-item"><a class="nav-link" asp-controller="Home" asp-action="Events">Events</a>
+                    <li class="nav-item"><a class="nav-link" asp-controller="Home" asp-action="About">About</a>
+                    <li class="nav-item"><a class="nav-link" asp-controller="Home" asp-action="Contact">Contact</a>
                 </ul>
             </div>
         </nav>
@@ -69,3 +69,5 @@
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>
+
+    <!---->

--- a/NeverNeverLand/appsettings.json
+++ b/NeverNeverLand/appsettings.json
@@ -14,43 +14,8 @@
     },
     "SendGrid": {
         "ApiKey": "",
-        "FromEmail": "noreply@neverneverland.com",
+        "FromEmail": "info@neverneverland.com",
         "FromName": "Never Never Land"
-    },
-    "Pricing": {
-        "TimeZone": "America/Los_Angeles",
-        "Seasons": [
-            {
-                "Name": "EarlyBird",
-                "Start": "01-01",
-                "End": "03-31",
-                "Prices": {
-                    "Personal": 89.99,
-                    "Family": 112.49,
-                    "FamilyPlus": 149.99
-                }
-            },
-            {
-                "Name": "Regular",
-                "Start": "04-01",
-                "End": "08-31",
-                "Prices": {
-                    "Personal": 119.99,
-                    "Family": 149.99,
-                    "FamilyPlus": 199.99
-                }
-            },
-            {
-                "Name": "Late-Season",
-                "Start": "09-01",
-                "End": "10-31",
-                "Prices": {
-                    "Personal": 77.99,
-                    "Family": 97.49,
-                    "FamilyPlus": 129.99
-                }
-            }
-        ]
     },
     "AllowedHosts": "*"
 }


### PR DESCRIPTION
We needed this so if we need to update prices or seasons, we would have to restart the server for the website. Now we also have logging capabilities to keep employees accountable for price changes.
